### PR TITLE
Fix nil connection panic in startClient

### DIFF
--- a/overmyhouse.go
+++ b/overmyhouse.go
@@ -103,9 +103,9 @@ func startServer(listener net.Listener) chan net.Conn {
 func startClient(feeder string) chan net.Conn {
 	ch := make(chan net.Conn)
 	go func() {
-		con, _ := net.Dial("tcp", feeder)
-		if con == nil {
-			_ = con.Close()
+		con, err := net.Dial("tcp", feeder)
+		if err != nil {
+			// retry once if the first attempt fails
 			con, _ = net.Dial("tcp", feeder)
 		}
 		ch <- con

--- a/overmyhouse_test.go
+++ b/overmyhouse_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// Test that startClient does not panic when connection cannot be established.
+func TestStartClient_NoPanic(t *testing.T) {
+	ch := startClient("invalid:0")
+	select {
+	case conn := <-ch:
+		if conn != nil {
+			conn.Close()
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("startClient did not return")
+	}
+}


### PR DESCRIPTION
## Summary
- avoid calling `Close` on a nil connection
- add regression test for `startClient`

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f43625b848333a68f41be2860665c