### PR TITLE
Add configurable notification channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,15 @@ Tweets to <https://twitter.com/overjamieshouse>
 
 ## Setup
 1.  go build
-2.  Stick a .env in the same dir as the binary containing twitter stuff: 
+2.  Stick a .env in the same dir as the binary containing twitter stuff:
 ```shell script
 consumerkey=
 consumersecret=
 accesstoken=
 accesssecret=
+slackwebhook=
 ```
-3.  ./overmyhouse
+3.  ./overmyhouse -notify=both # twitter, slack, or both
 ## Testing
 ``` shell script
 go test -v

--- a/notify.go
+++ b/notify.go
@@ -1,0 +1,23 @@
+package main
+
+import "log"
+
+func sendNotification(msg string) {
+	switch *notify {
+	case "twitter":
+		if _, err := tweet(msg); err != nil {
+			log.Print(err)
+		}
+	case "slack":
+		if err := slackNotify(msg); err != nil {
+			log.Print(err)
+		}
+	default: // both
+		if _, err := tweet(msg); err != nil {
+			log.Print(err)
+		}
+		if err := slackNotify(msg); err != nil {
+			log.Print(err)
+		}
+	}
+}

--- a/output.go
+++ b/output.go
@@ -53,12 +53,10 @@ func printOverhead(knownAircraft *KnownAircraft, tweetedAircraft *TweetedAircraf
 						durationSecondsElapsed(tPos))
 
 					if len(aircraft.callsign) > 0 {
-						_, err := tweet(fmt.Sprintf("https://flightaware.com/live/flight/%8s %8s flew %3.2f miles from my house at %d ft!",
-							aircraft.callsign, aircraft.callsign, metersInMiles(distance), aircraft.altitude))
+						msg := fmt.Sprintf("https://flightaware.com/live/flight/%8s %8s flew %3.2f miles from my house at %d ft!",
+							aircraft.callsign, aircraft.callsign, metersInMiles(distance), aircraft.altitude)
 
-						if err != nil {
-							log.Print(err)
-						}
+						sendNotification(msg)
 
 						tweetedAircraft.addAircraft(aircraft.callsign)
 					}

--- a/overmyhouse.go
+++ b/overmyhouse.go
@@ -27,6 +27,7 @@ var (
 	radius      = flag.Int("radius", 3, "Radius to alert on")
 	feeder      = flag.String("feeder", "192.168.1.50:30005", "IP and port of BEAST feed")
 	cleanupTime = flag.Int("cleanupTimeout", 60, "number of seconds after last contact before cleanup")
+	notify      = flag.String("notify", "both", "Where to send notifications: twitter, slack, or both")
 )
 
 func main() {

--- a/slack.go
+++ b/slack.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+
+	"github.com/joho/godotenv"
+)
+
+// slackNotify posts a message to a Slack incoming webhook.
+// The webhook URL is read from the `slackwebhook` environment variable.
+func slackNotify(message string) error {
+	_ = godotenv.Load()
+
+	webhookURL := os.Getenv("slackwebhook")
+	if len(webhookURL) == 0 {
+		return errors.New("Env isnt set correctly")
+	}
+
+	payload := map[string]string{"text": message}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.Post(webhookURL, "application/json", bytes.NewBuffer(b))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return errors.New("failed to post message to slack")
+	}
+
+	return nil
+}

--- a/slack_test.go
+++ b/slack_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestSlackNotify(t *testing.T) {
+	var received struct {
+		Text string `json:"text"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := ioutil.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	os.Setenv("slackwebhook", server.URL)
+	err := slackNotify("test message")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if received.Text != "test message" {
+		t.Fatalf("expected 'test message', got %s", received.Text)
+	}
+}
+
+func TestSlackNotifyMissingEnv(t *testing.T) {
+	os.Unsetenv("slackwebhook")
+	err := slackNotify("msg")
+	if err == nil {
+		t.Fatalf("expected error when env missing")
+	}
+}


### PR DESCRIPTION
## Summary
- add `notify` flag so notifications can be sent to twitter, slack or both
- implement `sendNotification` helper
- use new helper when alerting about aircraft
- document how to use the new flag

## Testing
- `go build ./...` *(fails: Get... Forbidden)*
- `go test ./...` *(fails: Get... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f44fa65788333aaf99f4fc1743ce8